### PR TITLE
export functions to get selected items

### DIFF
--- a/autoload/dir/action.vim
+++ b/autoload/dir/action.vim
@@ -9,7 +9,7 @@ import autoload 'dir/bookmark.vim'
 import autoload 'dir/history.vim'
 import autoload 'dir/fmt.vim'
 
-def VisualItemsInList(line1: number, line2: number): list<dict<any>>
+export def VisualItemsInList(line1: number, line2: number): list<dict<any>>
     var l1 = (line1 > line2 ? line2 : line1) - g.DIRLIST_SHIFT
     var l2 = (line2 > line1 ? line2 : line1) - g.DIRLIST_SHIFT
     if l2 < 0 | return [] | endif
@@ -17,13 +17,13 @@ def VisualItemsInList(line1: number, line2: number): list<dict<any>>
     return b:dir[l1 : l2]
 enddef
 
-def CursorItemInList(): dict<any>
+export def CursorItemInList(): dict<any>
     var idx = line('.') - g.DIRLIST_SHIFT
     if idx < 0 | return {name: ""} | endif
     return b:dir[idx]
 enddef
 
-def CursorItem(): string
+export def CursorItem(): string
     if line('.') == 1
         var view = winsaveview()
         var new_dir = getline(1)[0 : searchpos($'{os.Sep()->escape("\\")}\|$', 'c', 1)[1] - 1]


### PR DESCRIPTION
This PR exists because I want to get selected items in my vimrc, but there is no api to do it.
Maybe move these functions to g.vim?

Here is what I want to do:
```vimscript
vim9script

import autoload 'dir/action.vim'

def CustomizeMappings()
  noremap <buffer> g: <scriptcmd>DoFillCmdline()<cr>
enddef

def DoFillCmdline()
  const cfile = action.VisualItemsInList(line('v'), line('.'))->mapnew((idx, x) => x.name )->join(' ')

  const cmdline = $":\<C-U>! {cfile}\<HOME>\<S-Right> "
  feedkeys(cmdline)
enddef


augroup vimrc
  autocmd FileType dir CustomizeMappings()
augroup END
```