### PR TITLE
use dir.Open() to refresh in action.vim

### DIFF
--- a/autoload/dir/action.vim
+++ b/autoload/dir/action.vim
@@ -9,7 +9,7 @@ import autoload 'dir/bookmark.vim'
 import autoload 'dir/history.vim'
 import autoload 'dir/fmt.vim'
 
-def RefreshDir()
+export def RefreshDir()
     :edit
     if &shell == 'pwsh'
         :syntax on

--- a/autoload/dir/action.vim
+++ b/autoload/dir/action.vim
@@ -9,6 +9,13 @@ import autoload 'dir/bookmark.vim'
 import autoload 'dir/history.vim'
 import autoload 'dir/fmt.vim'
 
+def RefreshDir()
+    :edit
+    if &shell == 'pwsh'
+        :syntax on
+    endif
+enddef
+
 export def VisualItemsInList(line1: number, line2: number): list<dict<any>>
     var l1 = (line1 > line2 ? line2 : line1) - g.DIRLIST_SHIFT
     var l2 = (line2 > line1 ? line2 : line1) - g.DIRLIST_SHIFT
@@ -102,7 +109,7 @@ enddef
 export def DoFilterHidden()
     g:dir_show_hidden = !get(g:, "dir_show_hidden", "true")
     b:dir_invalidate = true
-    :edit
+    RefreshDir()
 
     var msg = g:dir_show_hidden ? "Show" : "Hide"
     g.Echo({t: msg, hl: "WarningMsg"}, " .hidden")
@@ -111,7 +118,7 @@ enddef
 export def DoFilter(bang: string, fltr: string)
     b:dir_filter = fltr
     b:dir_filter_bang = bang
-    :edit
+    RefreshDir()
 
     var msg = (empty(bang) ? "Show" : "Hide")
     g.Echo($"{msg} matched ", {t: $"{fltr}", hl: "WarningMsg"})
@@ -120,7 +127,7 @@ enddef
 export def DoFilterClear()
     b:dir_filter = ""
     b:dir_filter_bang = ""
-    :edit
+    RefreshDir()
 
     g.Echo("Show all!")
 enddef
@@ -166,7 +173,7 @@ export def DoDelete()
                     echohl None
                 endtry
             endfor
-            :edit
+            RefreshDir()
         })
     endif
 enddef
@@ -207,12 +214,12 @@ export def DoRename()
             os.RenameWithPattern($"{b:dir_cwd}/{item.name}", pattern, counter)
             counter += 1
         endfor
-        :edit
+        RefreshDir()
         winrestview(view)
     else
         var view = winsaveview()
         os.Rename($"{b:dir_cwd}/{del_list[0].name}")
-        :edit
+        RefreshDir()
         winrestview(view)
     endif
 enddef
@@ -247,7 +254,7 @@ export def DoCopy()
             var view = winsaveview()
             os.Duplicate()
             winrestview(view)
-            :edit
+            RefreshDir()
         endif
     else
         if cnt == 1
@@ -260,7 +267,7 @@ export def DoCopy()
             var view = winsaveview()
             os.Copy()
             winrestview(view)
-            :edit
+            RefreshDir()
         endif
     endif
 enddef
@@ -303,7 +310,7 @@ export def DoMove()
         var view = winsaveview()
         os.Move()
         winrestview(view)
-        :edit
+        RefreshDir()
         RefreshOtherDirWindows()
     endif
 enddef
@@ -320,7 +327,7 @@ export def DoCreateDir()
         name = $"{b:dir_cwd}/{name}"
     endif
     if os.CreateDir(name)
-        :edit
+        RefreshDir()
         winrestview(view)
         var first_dir = split(name, '[/\\]')[0]
         var idx = b:dir->indexof((_, val) => val.name == first_dir)
@@ -349,7 +356,7 @@ export def DoCompressGzip(items: list<any>)
     var view = winsaveview()
     mark.Clear()
     if os.CompressGzip(arch_name, items)
-        :edit
+        RefreshDir()
         winrestview(view)
         var idx = b:dir->indexof((_, val) => val.name == arch_name)
         if idx > -1
@@ -367,7 +374,7 @@ export def DoCompressZip(items: list<any>)
     var view = winsaveview()
     mark.Clear()
     if os.CompressZip(arch_name, items)
-        :edit
+        RefreshDir()
         winrestview(view)
         var idx = b:dir->indexof((_, val) => val.name == arch_name)
         if idx > -1
@@ -386,7 +393,7 @@ export def DoExtractArch(items: list<any>)
     var dir_name = input('Extract to: ', fnamemodify(items[0].name, ":t:r:r"))
     mark.Clear()
     if os.ExtractArch($"{b:dir_cwd}/{items[0].name}", $"{b:dir_cwd}/{dir_name}")
-        :edit
+        RefreshDir()
         winrestview(view)
     endif
 enddef
@@ -607,7 +614,7 @@ def RefreshOtherDirWindows()
     for buf_info in g.OtherDirBuffers()
         setbufvar(buf_info.bufnr, "dir_invalidate", true)
         for winid in buf_info.windows
-            win_execute(winid, ":edit", "silent!")
+            win_execute(winid, "RefreshDir()", "silent!")
         endfor
     endfor
 enddef

--- a/autoload/dir/os.vim
+++ b/autoload/dir/os.vim
@@ -210,7 +210,11 @@ export def Copy()
                     if !isdirectory(fnamemodify(dst, ":h"))
                         mkdir(fnamemodify(dst, ":h"), "p")
                     endif
-                    system($'{copy_cmd} "{resolve(src)}" "{dst}"')
+                    if &shell == 'pwsh'
+                        system($'{copy_cmd} "{resolve(src)}" "{dst}"'->escape('"'))
+                    else
+                        system($'{copy_cmd} "{resolve(src)}" "{dst}"')
+                    endif
                 endif
             endif
         catch
@@ -309,7 +313,11 @@ export def Move()
                     if !isdirectory(fnamemodify(dst, ":h"))
                         mkdir(fnamemodify(dst, ":h"), "p")
                     endif
-                    system($'{move_cmd} "{resolve(src)}" "{dst}"')
+                    if &shell == 'pwsh'
+                        system($'{move_cmd} "{resolve(src)}" "{dst}"'->escape('"'))
+                    else
+                        system($'{move_cmd} "{resolve(src)}" "{dst}"')
+                    endif
                 endif
             endif
         catch

--- a/autoload/dir/os.vim
+++ b/autoload/dir/os.vim
@@ -158,7 +158,9 @@ export def Copy()
     var copy_cmd = "cp"
     var dest_dir = $"{b:dir_cwd}"
 
-    if has("win32")
+    if &shell == 'pwsh'
+        copy_cmd = "Copy-Item -Force"
+    elseif has("win32")
         copy_cmd = "copy /Y"
     endif
 
@@ -255,7 +257,9 @@ export def Move()
     var move_cmd = "mv"
     var dest_dir = $"{b:dir_cwd}"
 
-    if has("win32")
+    if &shell == 'pwsh'
+        move_cmd = "Move-Item -Force"
+    elseif has("win32")
         move_cmd = "move /Y"
     endif
 

--- a/ftplugin/dir.vim
+++ b/ftplugin/dir.vim
@@ -64,7 +64,7 @@ xnoremap <buffer> s <nop>
 nnoremap <buffer> t <scriptcmd>action.Do("tabe")<cr>
 nnoremap <buffer> i <scriptcmd>action.DoInfo()<cr>
 nnoremap <buffer> <F3> <scriptcmd>action.DoInfo()<cr>
-nnoremap <buffer> <C-r> <scriptcmd>edit<cr>
+nnoremap <buffer> <C-r> <scriptcmd>action.RefreshDir()<cr>
 
 
 noremap <buffer> x <scriptcmd>action.DoMarkToggle()<cr>j


### PR DESCRIPTION
In Windows 11 on PowerShell 7.5.2, using Vim 9.1 1-1591. Calling `:edit` from the vim-dir window causes syntax highlighting to disappear. Destroying the buffer and re-opening it does not restore syntax highlighting. Calling `:syntax on` *does* restore syntax highlighting. Presumably, none of this happens in Linux, or someone would have opened a ticket by now.

This means most vim-dir functions break syntax highlighting in Windows, because they use `:edit` to refresh the vim-dir window after changes. I replaced the `:edit` calls in `action.vim` with `dir.Open()`. This allows most vim-dir functions to run successfully in Windows. If this is an acceptable fix, I will continue to address these small issues as I encounter them.

FWIW: I've additionally tried commenting out most of the syntax and ftplugin files to see if something there was causing this. That did not help.

PS: Pressing `i` *does* generate a file preview for me, despite what it says in the docs.